### PR TITLE
Analyze project and suggest improvements

### DIFF
--- a/custom_components/ha_portainer_link/sensor.py
+++ b/custom_components/ha_portainer_link/sensor.py
@@ -35,50 +35,65 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # Coordinator data is already loaded in main setup
     entities = []
     
-    # Create sensors for all containers
-    for container_id, container_data in coordinator.containers.items():
+    # Track which containers we've already created sensor entities for (by container_id)
+    created_for: set[str] = set()
+    
+    # Helper to create all sensors for a single container
+    def _create_container_sensors(container_id: str, container_data: dict) -> list:
         container_name = container_data.get("Names", ["unknown"])[0].strip("/")
-        
-        # Get detailed stack information from coordinator's processed data
         stack_info = coordinator.get_container_stack_info(container_id) or {
             "stack_name": None,
             "service_name": None,
             "container_number": None,
             "is_stack_container": False
         }
-        
         _LOGGER.debug("🔍 Processing container: %s (ID: %s, Stack: %s)", container_name, container_id, stack_info.get("stack_name"))
-        
+        new_entities = []
         # Always create status sensor (core functionality)
-        entities.append(ContainerStatusSensor(coordinator, entry_id, container_id, container_name, stack_info))
-        
-        # Create resource sensors only if enabled
+        new_entities.append(ContainerStatusSensor(coordinator, entry_id, container_id, container_name, stack_info))
+        # Resource sensors
         if resource_sensors_enabled:
-            entities.append(ContainerCPUSensor(coordinator, entry_id, container_id, container_name, stack_info))
-            entities.append(ContainerMemorySensor(coordinator, entry_id, container_id, container_name, stack_info))
-            entities.append(ContainerUptimeSensor(coordinator, entry_id, container_id, container_name, stack_info))
-        
-        # Create image and version sensors only if enabled
+            new_entities.append(ContainerCPUSensor(coordinator, entry_id, container_id, container_name, stack_info))
+            new_entities.append(ContainerMemorySensor(coordinator, entry_id, container_id, container_name, stack_info))
+            new_entities.append(ContainerUptimeSensor(coordinator, entry_id, container_id, container_name, stack_info))
+        # Version/image sensors
         if version_sensors_enabled:
-            entities.append(ContainerImageSensor(coordinator, entry_id, container_id, container_name, stack_info))
-            entities.append(ContainerCurrentVersionSensor(coordinator, entry_id, container_id, container_name, stack_info))
-            entities.append(ContainerAvailableVersionSensor(coordinator, entry_id, container_id, container_name, stack_info))
-            entities.append(ContainerCurrentDigestSensor(coordinator, entry_id, container_id, container_name, stack_info))
-            entities.append(ContainerAvailableDigestSensor(coordinator, entry_id, container_id, container_name, stack_info))
+            new_entities.append(ContainerImageSensor(coordinator, entry_id, container_id, container_name, stack_info))
+            new_entities.append(ContainerCurrentVersionSensor(coordinator, entry_id, container_id, container_name, stack_info))
+            new_entities.append(ContainerAvailableVersionSensor(coordinator, entry_id, container_id, container_name, stack_info))
+            new_entities.append(ContainerCurrentDigestSensor(coordinator, entry_id, container_id, container_name, stack_info))
+            new_entities.append(ContainerAvailableDigestSensor(coordinator, entry_id, container_id, container_name, stack_info))
+        return new_entities
+    
+    # Initial creation for all known containers
+    for container_id, container_data in coordinator.containers.items():
+        entities.extend(_create_container_sensors(container_id, container_data))
+        created_for.add(container_id)
 
     # Create stack-level sensors if stack view is enabled
     if coordinator.is_stack_view_enabled():
         for stack_name, stack_data in coordinator.stacks.items():
             _LOGGER.debug("🔍 Creating stack sensors for: %s", stack_name)
-            
-            # Create stack status sensor
             entities.append(StackStatusSensor(coordinator, entry_id, stack_name))
-            
-            # Create stack container count sensor
             entities.append(StackContainerCountSensor(coordinator, entry_id, stack_name))
     
     _LOGGER.info("✅ Created %d sensor entities", len(entities))
-    async_add_entities(entities, update_before_add=True)
+    # Register immediately; values will populate on next coordinator refresh
+    async_add_entities(entities, update_before_add=False)
+
+    # Dynamically add sensors for newly discovered containers on future updates
+    def _add_new_containers() -> None:
+        new_entities: list = []
+        for container_id, container_data in coordinator.containers.items():
+            if container_id not in created_for:
+                _LOGGER.info("➕ Discovered new container %s, creating sensors", container_id)
+                new_entities.extend(_create_container_sensors(container_id, container_data))
+                created_for.add(container_id)
+        if new_entities:
+            async_add_entities(new_entities, update_before_add=False)
+
+    # Listen for coordinator updates to discover new containers
+    coordinator.async_add_listener(_add_new_containers)
 
 class ContainerStatusSensor(BaseContainerEntity, SensorEntity):
     """Sensor for container status."""

--- a/custom_components/ha_portainer_link/switch.py
+++ b/custom_components/ha_portainer_link/switch.py
@@ -32,27 +32,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     
     # Coordinator data is already loaded in main setup
     entities = []
-    
-    # Debug: Check if we have containers
-    container_count = len(coordinator.containers)
-    _LOGGER.info("🔍 Found %d containers in coordinator", container_count)
-    
-    # Create switches for all containers
-    for container_id, container_data in coordinator.containers.items():
+
+    # Keep track of created switches to avoid duplicates
+    created_for: set[str] = set()
+
+    def _create_switch(container_id: str, container_data: dict) -> list:
         container_name = container_data.get("Names", ["unknown"])[0].strip("/")
-        
-        # Fix: Ensure container_state is a dictionary, not a string
-        container_state = container_data.get("State", {})
-        if isinstance(container_state, dict):
-            is_running = container_state.get("Running", False)
-        elif isinstance(container_state, str):
-            # Handle string state format (e.g., "running", "stopped")
-            is_running = container_state.lower() == "running"
-            _LOGGER.debug("🔍 Container %s has string state: %s (running: %s)", container_name, container_state, is_running)
-        else:
-            _LOGGER.warning("⚠️ Container state is not a dictionary for %s: %s", container_name, type(container_state))
-            is_running = False
-        
         # Get detailed stack information from coordinator's processed data
         stack_info = coordinator.get_container_stack_info(container_id) or {
             "stack_name": None,
@@ -60,15 +45,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
             "container_number": None,
             "is_stack_container": False
         }
-        
-        _LOGGER.debug("🔍 Processing container: %s (ID: %s, Stack: %s, Running: %s, State: %s)", 
-                     container_name, container_id, stack_info.get("stack_name"), is_running, container_state)
-        
-        # Always create container switches (core functionality)
-        switch_entity = ContainerSwitch(coordinator, entry_id, container_id, container_name, stack_info)
-        entities.append(switch_entity)
-        
-        _LOGGER.debug("✅ Created switch for container: %s (ID: %s)", container_name, container_id)
+        _LOGGER.debug("🔍 Processing container: %s (ID: %s, Stack: %s)", 
+                     container_name, container_id, stack_info.get("stack_name"))
+        return [ContainerSwitch(coordinator, entry_id, container_id, container_name, stack_info)]
+    
+    # Initial creation for all containers
+    for container_id, container_data in coordinator.containers.items():
+        entities.extend(_create_switch(container_id, container_data))
+        created_for.add(container_id)
 
     _LOGGER.info("✅ Created %d switch entities", len(entities))
     
@@ -76,7 +60,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for entity in entities:
         _LOGGER.debug("📋 Switch entity: %s (unique_id: %s)", entity.name, entity.unique_id)
     
-    async_add_entities(entities, update_before_add=True)
+    async_add_entities(entities, update_before_add=False)
+
+    # Dynamic addition when new containers are discovered
+    def _add_new_switches() -> None:
+        new_entities: list = []
+        for container_id, container_data in coordinator.containers.items():
+            if container_id not in created_for:
+                _LOGGER.info("➕ Discovered new container %s, creating switch", container_id)
+                new_entities.extend(_create_switch(container_id, container_data))
+                created_for.add(container_id)
+        if new_entities:
+            async_add_entities(new_entities, update_before_add=False)
+
+    coordinator.async_add_listener(_add_new_switches)
 
 
 class ContainerSwitch(BaseContainerEntity, SwitchEntity):

--- a/custom_components/ha_portainer_link/update.py
+++ b/custom_components/ha_portainer_link/update.py
@@ -22,20 +22,38 @@ async def async_setup_entry(hass, entry, async_add_entities):
         return
 
     entities = []
-    for container_id, container_data in coordinator.containers.items():
-        container_name = container_data.get("Names", ["unknown"])[0].strip("/")
+    created_for: set[str] = set()
 
+    def _create_update_entity(container_id: str, container_data: dict) -> list:
+        container_name = container_data.get("Names", ["unknown"])[0].strip("/")
         stack_info = coordinator.get_container_stack_info(container_id) or {
             "stack_name": None,
             "service_name": None,
             "container_number": None,
             "is_stack_container": False,
         }
+        return [ContainerUpdateEntity(coordinator, entry_id, container_id, container_name, stack_info)]
 
-        entities.append(ContainerUpdateEntity(coordinator, entry_id, container_id, container_name, stack_info))
+    # Initial entities
+    for container_id, container_data in coordinator.containers.items():
+        entities.extend(_create_update_entity(container_id, container_data))
+        created_for.add(container_id)
 
     _LOGGER.info("✅ Created %d update entities", len(entities))
-    async_add_entities(entities, update_before_add=True)
+    async_add_entities(entities, update_before_add=False)
+
+    # Dynamic add on coordinator updates
+    def _add_new_update_entities() -> None:
+        new_entities: list = []
+        for container_id, container_data in coordinator.containers.items():
+            if container_id not in created_for:
+                _LOGGER.info("➕ Discovered new container %s, creating update entity", container_id)
+                new_entities.extend(_create_update_entity(container_id, container_data))
+                created_for.add(container_id)
+        if new_entities:
+            async_add_entities(new_entities, update_before_add=False)
+
+    coordinator.async_add_listener(_add_new_update_entities)
 
 
 class ContainerUpdateEntity(BaseContainerEntity, UpdateEntity):


### PR DESCRIPTION
Implement dynamic sensor creation for containers to ensure sensors appear even if a container starts after integration load.

Previously, sensors were only created for containers present at integration load. This change allows sensors for containers that start or become available later to be added dynamically on subsequent coordinator updates, resolving issues where sensors might not appear without a full integration reload. It also registers entities immediately, preventing delays in their appearance in Home Assistant.

---
<a href="https://cursor.com/background-agent?bcId=bc-04af5297-1b8b-4aa7-ba4d-78ce47c900eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04af5297-1b8b-4aa7-ba4d-78ce47c900eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

