### PR TITLE
Investigate dashboard creation failure

### DIFF
--- a/custom_components/ha_portainer_link/__init__.py
+++ b/custom_components/ha_portainer_link/__init__.py
@@ -18,8 +18,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
         except Exception as e:  # noqa: BLE001
             _LOGGER.warning("Dashboard helper unavailable: %s", e)
             return
-        title = call.data.get("title") or "HA Protainer Link"
-        url_path = call.data.get("url_path") or "ha-protainer-link"
+        title = call.data.get("title") or "HA Portainer Link"
+        url_path = call.data.get("url_path") or "ha-portainer-link"
         try:
             await ensure_dashboard_exists(hass, title=title, url_path=url_path)
             _LOGGER.info("Dashboard '%s' ensured at /%s", title, url_path)
@@ -42,8 +42,8 @@ async def _maybe_create_dashboard(hass: HomeAssistant, entry: ConfigEntry) -> No
         _LOGGER.debug("Dashboard helper not available: %s", e)
         return
 
-    title: str = data.get("dashboard_title", "HA Protainer Link")
-    url_path: str = data.get("dashboard_path", "ha-protainer-link")
+    title: str = data.get("dashboard_title", "HA Portainer Link")
+    url_path: str = data.get("dashboard_path", "ha-portainer-link")
     try:
         await ensure_dashboard_exists(hass, title=title, url_path=url_path)
         _LOGGER.info("Ensured dashboard '%s' at /%s exists", title, url_path)
@@ -65,11 +65,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
+    # Start dashboard creation concurrently so it's not blocked by platform setup
+    hass.async_create_task(_maybe_create_dashboard(hass, entry))
+
     # ✅ Richtiger Aufruf!
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    # Optionally create the Lovelace dashboard
-    await _maybe_create_dashboard(hass, entry)
 
     return True
 

--- a/custom_components/ha_portainer_link/config_flow.py
+++ b/custom_components/ha_portainer_link/config_flow.py
@@ -34,8 +34,8 @@ class PortainerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_dashboard(self, user_input=None):
         if user_input is not None:
             create_dashboard = user_input.get("create_dashboard", True)
-            dashboard_path = user_input.get("dashboard_path", "ha-protainer-link")
-            dashboard_title = user_input.get("dashboard_title", "HA Protainer Link")
+            dashboard_path = user_input.get("dashboard_path", "ha-portainer-link")
+            dashboard_title = user_input.get("dashboard_title", "HA Portainer Link")
 
             data = dict(self._user_input or {})
             data.update({
@@ -47,8 +47,8 @@ class PortainerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema({
             vol.Required("create_dashboard", default=True): bool,
-            vol.Optional("dashboard_title", default="HA Protainer Link"): str,
-            vol.Optional("dashboard_path", default="ha-protainer-link"): str,
+            vol.Optional("dashboard_title", default="HA Portainer Link"): str,
+            vol.Optional("dashboard_path", default="ha-portainer-link"): str,
         })
         return self.async_show_form(step_id="dashboard", data_schema=schema)
 

--- a/custom_components/ha_portainer_link/dashboard.py
+++ b/custom_components/ha_portainer_link/dashboard.py
@@ -8,8 +8,8 @@ from homeassistant.helpers import entity_registry as er, device_registry as dr
 
 _LOGGER = logging.getLogger(__name__)
 
-DASHBOARD_PATH_DEFAULT = "ha-protainer-link"
-DASHBOARD_TITLE_DEFAULT = "HA Protainer Link"
+DASHBOARD_PATH_DEFAULT = "ha-portainer-link"
+DASHBOARD_TITLE_DEFAULT = "HA Portainer Link"
 
 
 async def ensure_dashboard_exists(hass: HomeAssistant, *, title: str = DASHBOARD_TITLE_DEFAULT, url_path: str = DASHBOARD_PATH_DEFAULT) -> None:

--- a/custom_components/ha_portainer_link/services.yaml
+++ b/custom_components/ha_portainer_link/services.yaml
@@ -9,20 +9,20 @@ refresh:
   fields: {}
 
 create_dashboard:
-  name: "Create HA Protainer Link Dashboard"
-  description: "Create or update the 'HA Protainer Link' Lovelace dashboard with views and entities"
+  name: "Create HA Portainer Link Dashboard"
+  description: "Create or update the 'HA Portainer Link' Lovelace dashboard with views and entities"
   fields:
     title:
       name: "Title"
       description: "Dashboard title"
       required: false
-      example: "HA Protainer Link"
+      example: "HA Portainer Link"
       selector:
         text: {}
     url_path:
       name: "URL Path"
       description: "Dashboard URL path (slug)"
       required: false
-      example: "ha-protainer-link"
+      example: "ha-portainer-link"
       selector:
         text: {}


### PR DESCRIPTION
Make dashboard creation concurrent to prevent blocking by platform setup and correct 'Protainer' typos to 'Portainer'.

---
<a href="https://cursor.com/background-agent?bcId=bc-535fc4cc-2efc-47e0-a9de-39add95f839f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-535fc4cc-2efc-47e0-a9de-39add95f839f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

