### PR TITLE
Fix dashboard creation using homeassistant docs

### DIFF
--- a/custom_components/ha_portainer_link/manifest.json
+++ b/custom_components/ha_portainer_link/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.5.7",
   "documentation": "https://github.com/rob0r7/ha_portainer_link",
   "dependencies": [],
+  "after_dependencies": ["lovelace"],
   "codeowners": ["@rob0r7"],
   "requirements": ["requests"],
   "iot_class": "local_polling",


### PR DESCRIPTION
Update dashboard creation to align with Home Assistant Lovelace API changes and ensure proper component initialization.

The previous dashboard creation logic failed due to changes in Home Assistant's internal Lovelace storage APIs and potential race conditions where Lovelace was not fully initialized. This PR updates method calls for broader HA version compatibility, removes an unsupported argument, and adds a dependency to ensure Lovelace is ready before dashboard operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-f564bd43-1871-447d-bd41-4348e3f4efb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f564bd43-1871-447d-bd41-4348e3f4efb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

